### PR TITLE
feat: Implement ReceiptItem entity for Issue #21

### DIFF
--- a/api/src/domain/entities/ReceiptItem.ts
+++ b/api/src/domain/entities/ReceiptItem.ts
@@ -1,0 +1,418 @@
+// api/src/domain/entities/ReceiptItem.ts
+import { Money } from '../value-objects/Money';
+import { ReceiptDate } from '../value-objects/ReceiptDate';
+
+/**
+ * レシートアイテムID値オブジェクト
+ * UUIDv4形式の一意識別子
+ */
+export class ReceiptItemId {
+  public readonly value: string;
+
+  private constructor(value: string) {
+    this.value = value;
+    Object.freeze(this);
+  }
+
+  public static create(id: string): ReceiptItemId {
+    if (!id || typeof id !== 'string') {
+      throw new Error('ReceiptItemId cannot be empty');
+    }
+
+    const trimmedId = id.trim();
+    
+    // UUIDv4形式の検証
+    const uuidRegex = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+    if (!uuidRegex.test(trimmedId)) {
+      throw new Error('ReceiptItemId must be a valid UUIDv4');
+    }
+
+    return new ReceiptItemId(trimmedId);
+  }
+
+  public static generate(): ReceiptItemId {
+    // UUIDv4の生成（RFC4122準拠）
+    const uuid = 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, function(c) {
+      const r = Math.random() * 16 | 0;
+      const v = c === 'x' ? r : (r & 0x3 | 0x8);
+      return v.toString(16);
+    });
+    
+    return new ReceiptItemId(uuid);
+  }
+
+  public equals(other?: ReceiptItemId): boolean {
+    if (!other || !(other instanceof ReceiptItemId)) {
+      return false;
+    }
+    return this.value === other.value;
+  }
+
+  public toString(): string {
+    return this.value;
+  }
+}
+
+/**
+ * 勘定科目値オブジェクト
+ * 日本の会計基準に基づく勘定科目の管理
+ */
+export class AccountCategory {
+  public readonly value: string;
+
+  private constructor(value: string) {
+    this.value = value;
+    Object.freeze(this);
+  }
+
+  // 一般的な経費勘定科目
+  private static readonly COMMON_CATEGORIES = [
+    '消耗品費', '事務用品費', '交通費', '会議費', '接待交際費',
+    '通信費', '水道光熱費', '賃借料', '保険料', '修繕費',
+    '広告宣伝費', '研修費', '図書費', '旅費交通費', '雑費'
+  ] as const;
+
+  public static create(category: string): AccountCategory {
+    if (!category || typeof category !== 'string') {
+      throw new Error('Account category cannot be empty');
+    }
+
+    const trimmedCategory = category.trim();
+    
+    if (trimmedCategory.length === 0) {
+      throw new Error('Account category cannot be empty');
+    }
+
+    if (trimmedCategory.length > 50) {
+      throw new Error('Account category is too long (max 50 characters)');
+    }
+
+    // 日本語文字、英数字、一部記号のみ許可
+    const validCharRegex = /^[\u3040-\u309F\u30A0-\u30FF\u4E00-\u9FAFa-zA-Z0-9\s・ー（）()]+$/;
+    if (!validCharRegex.test(trimmedCategory)) {
+      throw new Error('Account category contains invalid characters');
+    }
+
+    return new AccountCategory(trimmedCategory);
+  }
+
+  public static getCommonCategories(): readonly string[] {
+    return AccountCategory.COMMON_CATEGORIES;
+  }
+
+  public isCommonCategory(): boolean {
+    return AccountCategory.COMMON_CATEGORIES.includes(this.value as any);
+  }
+
+  public equals(other?: AccountCategory): boolean {
+    if (!other || !(other instanceof AccountCategory)) {
+      return false;
+    }
+    return this.value === other.value;
+  }
+
+  public toString(): string {
+    return this.value;
+  }
+}
+
+/**
+ * 税務上の注意点値オブジェクト
+ * 税務申告時の注意事項やメモを管理
+ */
+export class TaxNote {
+  public readonly value: string;
+
+  private constructor(value: string) {
+    this.value = value;
+    Object.freeze(this);
+  }
+
+  public static create(note: string): TaxNote {
+    if (!note || typeof note !== 'string') {
+      throw new Error('Tax note cannot be empty');
+    }
+
+    const trimmedNote = note.trim();
+    
+    if (trimmedNote.length === 0) {
+      throw new Error('Tax note cannot be empty');
+    }
+
+    if (trimmedNote.length > 500) {
+      throw new Error('Tax note is too long (max 500 characters)');
+    }
+
+    // HTMLタグ、スクリプトの除去（XSS対策）
+    if (/<script|javascript:|on\w+=/i.test(trimmedNote)) {
+      throw new Error('Tax note contains unsafe content');
+    }
+
+    return new TaxNote(trimmedNote);
+  }
+
+  public static createOptional(note?: string): TaxNote | undefined {
+    if (!note || note.trim().length === 0) {
+      return undefined;
+    }
+    return TaxNote.create(note);
+  }
+
+  public equals(other?: TaxNote): boolean {
+    if (!other || !(other instanceof TaxNote)) {
+      return false;
+    }
+    return this.value === other.value;
+  }
+
+  public toString(): string {
+    return this.value;
+  }
+}
+
+/**
+ * 商品名値オブジェクト
+ * レシート上の商品・サービス名を管理
+ */
+export class ItemName {
+  public readonly value: string;
+
+  private constructor(value: string) {
+    this.value = value;
+    Object.freeze(this);
+  }
+
+  public static create(name: string): ItemName {
+    if (!name || typeof name !== 'string') {
+      throw new Error('Item name cannot be empty');
+    }
+
+    const trimmedName = name.trim();
+    
+    if (trimmedName.length === 0) {
+      throw new Error('Item name cannot be empty');
+    }
+
+    if (trimmedName.length > 200) {
+      throw new Error('Item name is too long (max 200 characters)');
+    }
+
+    // HTMLタグ、スクリプトの除去（XSS対策）
+    if (/<script|javascript:|on\w+=/i.test(trimmedName)) {
+      throw new Error('Item name contains unsafe content');
+    }
+
+    return new ItemName(trimmedName);
+  }
+
+  public equals(other?: ItemName): boolean {
+    if (!other || !(other instanceof ItemName)) {
+      return false;
+    }
+    return this.value === other.value;
+  }
+
+  public toString(): string {
+    return this.value;
+  }
+}
+
+/**
+ * レシートアイテムエンティティ
+ * 1つのレシート項目を表すドメインエンティティ
+ */
+export class ReceiptItem {
+  public readonly id: ReceiptItemId;
+  public readonly name: ItemName;
+  public readonly price: Money;
+  public readonly accountCategory?: AccountCategory;
+  public readonly taxNote?: TaxNote;
+  public readonly purchaseDate: ReceiptDate;
+  private readonly _createdAt: Date;
+  private _updatedAt: Date;
+
+  private constructor(props: {
+    id: ReceiptItemId;
+    name: ItemName;
+    price: Money;
+    accountCategory?: AccountCategory;
+    taxNote?: TaxNote;
+    purchaseDate: ReceiptDate;
+    createdAt?: Date;
+    updatedAt?: Date;
+  }) {
+    this.id = props.id;
+    this.name = props.name;
+    this.price = props.price;
+    this.accountCategory = props.accountCategory;
+    this.taxNote = props.taxNote;
+    this.purchaseDate = props.purchaseDate;
+    this._createdAt = props.createdAt || new Date();
+    this._updatedAt = props.updatedAt || new Date();
+    
+    Object.freeze(this);
+  }
+
+  /**
+   * 新しいReceiptItemを作成
+   */
+  public static create(props: {
+    name: string;
+    priceInYen: number;
+    accountCategory?: string;
+    taxNote?: string;
+    purchaseDate: string | Date;
+  }): ReceiptItem {
+    return new ReceiptItem({
+      id: ReceiptItemId.generate(),
+      name: ItemName.create(props.name),
+      price: Money.fromYen(props.priceInYen),
+      accountCategory: props.accountCategory ? AccountCategory.create(props.accountCategory) : undefined,
+      taxNote: TaxNote.createOptional(props.taxNote),
+      purchaseDate: ReceiptDate.create(props.purchaseDate)
+    });
+  }
+
+  /**
+   * 既存のReceiptItemを復元（永続化層からの復元時に使用）
+   */
+  public static restore(props: {
+    id: string;
+    name: string;
+    priceInYen: number;
+    accountCategory?: string;
+    taxNote?: string;
+    purchaseDate: string | Date;
+    createdAt: Date;
+    updatedAt: Date;
+  }): ReceiptItem {
+    return new ReceiptItem({
+      id: ReceiptItemId.create(props.id),
+      name: ItemName.create(props.name),
+      price: Money.fromYen(props.priceInYen),
+      accountCategory: props.accountCategory ? AccountCategory.create(props.accountCategory) : undefined,
+      taxNote: TaxNote.createOptional(props.taxNote),
+      purchaseDate: ReceiptDate.create(props.purchaseDate),
+      createdAt: props.createdAt,
+      updatedAt: props.updatedAt
+    });
+  }
+
+  public get createdAt(): Date {
+    return this._createdAt;
+  }
+
+  public get updatedAt(): Date {
+    return this._updatedAt;
+  }
+
+  /**
+   * 勘定科目を更新（新しいインスタンスを返す）
+   */
+  public updateAccountCategory(category: string): ReceiptItem {
+    return new ReceiptItem({
+      id: this.id,
+      name: this.name,
+      price: this.price,
+      accountCategory: AccountCategory.create(category),
+      taxNote: this.taxNote,
+      purchaseDate: this.purchaseDate,
+      createdAt: this._createdAt,
+      updatedAt: new Date()
+    });
+  }
+
+  /**
+   * 税務メモを更新（新しいインスタンスを返す）
+   */
+  public updateTaxNote(note: string): ReceiptItem {
+    return new ReceiptItem({
+      id: this.id,
+      name: this.name,
+      price: this.price,
+      accountCategory: this.accountCategory,
+      taxNote: TaxNote.create(note),
+      purchaseDate: this.purchaseDate,
+      createdAt: this._createdAt,
+      updatedAt: new Date()
+    });
+  }
+
+  /**
+   * IDによる等価比較
+   */
+  public equals(other?: ReceiptItem): boolean {
+    if (!other || !(other instanceof ReceiptItem)) {
+      return false;
+    }
+    return this.id.equals(other.id);
+  }
+
+  /**
+   * 経費として計上可能かチェック
+   */
+  public isDeductibleExpense(): boolean {
+    // 基本的に全ての項目は経費として計上可能
+    // ビジネスルールに応じて条件を追加
+    return this.price.yenAmount > 0;
+  }
+
+  /**
+   * 高額商品かチェック（10万円以上）
+   */
+  public isHighValueItem(): boolean {
+    return this.price.yenAmount >= 100000;
+  }
+
+  /**
+   * 表示用の文字列表現
+   */
+  public toString(): string {
+    const categoryStr = this.accountCategory ? ` [${this.accountCategory.value}]` : '';
+    return `${this.name.value}: ${this.price.format()}${categoryStr} (${this.purchaseDate.formatForDisplay()})`;
+  }
+
+  /**
+   * 永続化用のプレーンオブジェクトに変換
+   */
+  public toPersistenceObject(): {
+    id: string;
+    name: string;
+    price: number;
+    accountCategory?: string;
+    taxNote?: string;
+    purchaseDate: string;
+    createdAt: Date;
+    updatedAt: Date;
+  } {
+    return {
+      id: this.id.value,
+      name: this.name.value,
+      price: this.price.yenAmount,
+      accountCategory: this.accountCategory?.value,
+      taxNote: this.taxNote?.value,
+      purchaseDate: this.purchaseDate.value,
+      createdAt: this._createdAt,
+      updatedAt: this._updatedAt
+    };
+  }
+
+  /**
+   * CSV出力用のデータに変換
+   */
+  public toCsvData(): {
+    購入日: string;
+    商品名: string;
+    金額: string;
+    勘定科目: string;
+    税務メモ: string;
+  } {
+    return {
+      購入日: this.purchaseDate.formatForDisplay(),
+      商品名: this.name.value,
+      金額: this.price.format(),
+      勘定科目: this.accountCategory?.value || '',
+      税務メモ: this.taxNote?.value || ''
+    };
+  }
+}

--- a/api/src/tests/domain/entities/ReceiptItem.spec.ts
+++ b/api/src/tests/domain/entities/ReceiptItem.spec.ts
@@ -1,0 +1,392 @@
+// api/src/tests/domain/entities/ReceiptItem.spec.ts
+import { describe, it, expect, beforeEach } from '@jest/globals';
+import {
+  ReceiptItem,
+  ReceiptItemId,
+  AccountCategory,
+  TaxNote,
+  ItemName
+} from '../../../domain/entities/ReceiptItem';
+import { Money } from '../../../domain/value-objects/Money';
+import { ReceiptDate } from '../../../domain/value-objects/ReceiptDate';
+
+describe('ReceiptItemId', () => {
+  describe('create', () => {
+    it('有効なUUIDv4からReceiptItemIdを作成できる', () => {
+      const validUuid = '12345678-1234-4123-8123-123456789abc';
+      const id = ReceiptItemId.create(validUuid);
+      expect(id.value).toBe(validUuid);
+    });
+
+    it('無効なUUIDフォーマットでエラーが発生する', () => {
+      expect(() => ReceiptItemId.create('invalid-uuid')).toThrow('ReceiptItemId must be a valid UUIDv4');
+    });
+
+    it('空文字列でエラーが発生する', () => {
+      expect(() => ReceiptItemId.create('')).toThrow('ReceiptItemId cannot be empty');
+    });
+
+    it('nullでエラーが発生する', () => {
+      expect(() => ReceiptItemId.create(null as any)).toThrow('ReceiptItemId cannot be empty');
+    });
+  });
+
+  describe('generate', () => {
+    it('新しいUUIDv4を生成できる', () => {
+      const id = ReceiptItemId.generate();
+      expect(id.value).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i);
+    });
+
+    it('生成される度に異なるIDになる', () => {
+      const id1 = ReceiptItemId.generate();
+      const id2 = ReceiptItemId.generate();
+      expect(id1.value).not.toBe(id2.value);
+    });
+  });
+
+  describe('equals', () => {
+    it('同じ値の場合にtrueを返す', () => {
+      const uuid = '12345678-1234-4123-8123-123456789abc';
+      const id1 = ReceiptItemId.create(uuid);
+      const id2 = ReceiptItemId.create(uuid);
+      expect(id1.equals(id2)).toBe(true);
+    });
+
+    it('異なる値の場合にfalseを返す', () => {
+      const id1 = ReceiptItemId.create('12345678-1234-4123-8123-123456789abc');
+      const id2 = ReceiptItemId.create('87654321-4321-4321-8321-cba987654321');
+      expect(id1.equals(id2)).toBe(false);
+    });
+  });
+});
+
+describe('AccountCategory', () => {
+  describe('create', () => {
+    it('有効な勘定科目を作成できる', () => {
+      const category = AccountCategory.create('消耗品費');
+      expect(category.value).toBe('消耗品費');
+    });
+
+    it('英数字を含む勘定科目を作成できる', () => {
+      const category = AccountCategory.create('IT関連費');
+      expect(category.value).toBe('IT関連費');
+    });
+
+    it('空文字列でエラーが発生する', () => {
+      expect(() => AccountCategory.create('')).toThrow('Account category cannot be empty');
+    });
+
+    it('長すぎる文字列でエラーが発生する', () => {
+      const longString = 'a'.repeat(51);
+      expect(() => AccountCategory.create(longString)).toThrow('Account category is too long');
+    });
+
+    it('不正な文字でエラーが発生する', () => {
+      expect(() => AccountCategory.create('科目<script>')).toThrow('Account category contains invalid characters');
+    });
+  });
+
+  describe('getCommonCategories', () => {
+    it('一般的な勘定科目一覧を取得できる', () => {
+      const categories = AccountCategory.getCommonCategories();
+      expect(categories).toContain('消耗品費');
+      expect(categories).toContain('交通費');
+      expect(categories.length).toBeGreaterThan(0);
+    });
+  });
+
+  describe('isCommonCategory', () => {
+    it('一般的な勘定科目の場合にtrueを返す', () => {
+      const category = AccountCategory.create('消耗品費');
+      expect(category.isCommonCategory()).toBe(true);
+    });
+
+    it('独自の勘定科目の場合にfalseを返す', () => {
+      const category = AccountCategory.create('特別な経費');
+      expect(category.isCommonCategory()).toBe(false);
+    });
+  });
+});
+
+describe('TaxNote', () => {
+  describe('create', () => {
+    it('有効な税務メモを作成できる', () => {
+      const note = TaxNote.create('消費税10%適用');
+      expect(note.value).toBe('消費税10%適用');
+    });
+
+    it('空文字列でエラーが発生する', () => {
+      expect(() => TaxNote.create('')).toThrow('Tax note cannot be empty');
+    });
+
+    it('長すぎる文字列でエラーが発生する', () => {
+      const longString = 'a'.repeat(501);
+      expect(() => TaxNote.create(longString)).toThrow('Tax note is too long');
+    });
+
+    it('安全でないコンテンツでエラーが発生する', () => {
+      expect(() => TaxNote.create('<script>alert("xss")</script>')).toThrow('Tax note contains unsafe content');
+    });
+  });
+
+  describe('createOptional', () => {
+    it('有効な値でTaxNoteを作成できる', () => {
+      const note = TaxNote.createOptional('有効なメモ');
+      expect(note).toBeDefined();
+      expect(note!.value).toBe('有効なメモ');
+    });
+
+    it('空文字列でundefinedを返す', () => {
+      const note = TaxNote.createOptional('');
+      expect(note).toBeUndefined();
+    });
+
+    it('undefinedでundefinedを返す', () => {
+      const note = TaxNote.createOptional(undefined);
+      expect(note).toBeUndefined();
+    });
+  });
+});
+
+describe('ItemName', () => {
+  describe('create', () => {
+    it('有効な商品名を作成できる', () => {
+      const name = ItemName.create('コーヒー豆500g');
+      expect(name.value).toBe('コーヒー豆500g');
+    });
+
+    it('空文字列でエラーが発生する', () => {
+      expect(() => ItemName.create('')).toThrow('Item name cannot be empty');
+    });
+
+    it('長すぎる文字列でエラーが発生する', () => {
+      const longString = 'a'.repeat(201);
+      expect(() => ItemName.create(longString)).toThrow('Item name is too long');
+    });
+
+    it('安全でないコンテンツでエラーが発生する', () => {
+      expect(() => ItemName.create('<script>alert("xss")</script>')).toThrow('Item name contains unsafe content');
+    });
+  });
+});
+
+describe('ReceiptItem', () => {
+  const validProps = {
+    name: 'テストアイテム',
+    priceInYen: 1000,
+    accountCategory: '消耗品費',
+    taxNote: '消費税10%',
+    purchaseDate: '2024-01-15'
+  };
+
+  describe('create', () => {
+    it('有効な値でReceiptItemを作成できる', () => {
+      const item = ReceiptItem.create(validProps);
+      
+      expect(item.name.value).toBe('テストアイテム');
+      expect(item.price.yenAmount).toBe(1000);
+      expect(item.accountCategory!.value).toBe('消耗品費');
+      expect(item.taxNote!.value).toBe('消費税10%');
+      expect(item.purchaseDate.value).toBe('2024-01-15');
+      expect(item.id).toBeDefined();
+      expect(item.createdAt).toBeDefined();
+      expect(item.updatedAt).toBeDefined();
+    });
+
+    it('オプショナルな値なしでReceiptItemを作成できる', () => {
+      const item = ReceiptItem.create({
+        name: 'シンプルアイテム',
+        priceInYen: 500,
+        purchaseDate: '2024-01-15'
+      });
+      
+      expect(item.name.value).toBe('シンプルアイテム');
+      expect(item.price.yenAmount).toBe(500);
+      expect(item.accountCategory).toBeUndefined();
+      expect(item.taxNote).toBeUndefined();
+    });
+
+    it('無効な値でエラーが発生する', () => {
+      expect(() => ReceiptItem.create({
+        ...validProps,
+        name: ''
+      })).toThrow();
+    });
+  });
+
+  describe('restore', () => {
+    it('永続化データからReceiptItemを復元できる', () => {
+      const createdAt = new Date('2024-01-01');
+      const updatedAt = new Date('2024-01-02');
+      
+      const item = ReceiptItem.restore({
+        id: '12345678-1234-4123-8123-123456789abc',
+        name: '復元アイテム',
+        priceInYen: 1500,
+        accountCategory: '交通費',
+        taxNote: '領収書あり',
+        purchaseDate: '2024-01-15',
+        createdAt,
+        updatedAt
+      });
+      
+      expect(item.id.value).toBe('12345678-1234-4123-8123-123456789abc');
+      expect(item.name.value).toBe('復元アイテム');
+      expect(item.price.yenAmount).toBe(1500);
+      expect(item.createdAt).toBe(createdAt);
+      expect(item.updatedAt).toBe(updatedAt);
+    });
+  });
+
+  describe('updateAccountCategory', () => {
+    it('勘定科目を更新した新しいインスタンスを返す', async () => {
+      const original = ReceiptItem.create(validProps);
+      
+      // 時間差を確保するために少し待機
+      await new Promise(resolve => setTimeout(resolve, 1));
+      
+      const updated = original.updateAccountCategory('会議費');
+      
+      expect(updated.accountCategory!.value).toBe('会議費');
+      expect(updated.id.equals(original.id)).toBe(true);
+      expect(updated.updatedAt.getTime()).toBeGreaterThanOrEqual(original.updatedAt.getTime());
+      expect(original.accountCategory!.value).toBe('消耗品費'); // 元のオブジェクトは変更されない
+    });
+  });
+
+  describe('updateTaxNote', () => {
+    it('税務メモを更新した新しいインスタンスを返す', async () => {
+      const original = ReceiptItem.create(validProps);
+      
+      // 時間差を確保するために少し待機
+      await new Promise(resolve => setTimeout(resolve, 1));
+      
+      const updated = original.updateTaxNote('新しいメモ');
+      
+      expect(updated.taxNote!.value).toBe('新しいメモ');
+      expect(updated.id.equals(original.id)).toBe(true);
+      expect(updated.updatedAt.getTime()).toBeGreaterThanOrEqual(original.updatedAt.getTime());
+    });
+  });
+
+  describe('equals', () => {
+    it('同じIDの場合にtrueを返す', () => {
+      const item1 = ReceiptItem.create(validProps);
+      const item2 = ReceiptItem.restore({
+        id: item1.id.value,
+        name: '異なる名前',
+        priceInYen: 9999,
+        purchaseDate: '2020-01-01',
+        createdAt: new Date(),
+        updatedAt: new Date()
+      });
+      
+      expect(item1.equals(item2)).toBe(true);
+    });
+
+    it('異なるIDの場合にfalseを返す', () => {
+      const item1 = ReceiptItem.create(validProps);
+      const item2 = ReceiptItem.create(validProps);
+      
+      expect(item1.equals(item2)).toBe(false);
+    });
+  });
+
+  describe('isDeductibleExpense', () => {
+    it('金額が0より大きい場合にtrueを返す', () => {
+      const item = ReceiptItem.create(validProps);
+      expect(item.isDeductibleExpense()).toBe(true);
+    });
+
+    it('金額が0の場合にfalseを返す', () => {
+      const item = ReceiptItem.create({
+        ...validProps,
+        priceInYen: 0
+      });
+      expect(item.isDeductibleExpense()).toBe(false);
+    });
+  });
+
+  describe('isHighValueItem', () => {
+    it('10万円以上の場合にtrueを返す', () => {
+      const item = ReceiptItem.create({
+        ...validProps,
+        priceInYen: 100000
+      });
+      expect(item.isHighValueItem()).toBe(true);
+    });
+
+    it('10万円未満の場合にfalseを返す', () => {
+      const item = ReceiptItem.create({
+        ...validProps,
+        priceInYen: 99999
+      });
+      expect(item.isHighValueItem()).toBe(false);
+    });
+  });
+
+  describe('toPersistenceObject', () => {
+    it('永続化用のオブジェクトに変換できる', () => {
+      const item = ReceiptItem.create(validProps);
+      const obj = item.toPersistenceObject();
+      
+      expect(obj.id).toBe(item.id.value);
+      expect(obj.name).toBe('テストアイテム');
+      expect(obj.price).toBe(1000);
+      expect(obj.accountCategory).toBe('消耗品費');
+      expect(obj.taxNote).toBe('消費税10%');
+      expect(obj.purchaseDate).toBe('2024-01-15');
+      expect(obj.createdAt).toBe(item.createdAt);
+      expect(obj.updatedAt).toBe(item.updatedAt);
+    });
+
+    it('オプショナルな値がundefinedの場合も正しく変換できる', () => {
+      const item = ReceiptItem.create({
+        name: 'シンプルアイテム',
+        priceInYen: 500,
+        purchaseDate: '2024-01-15'
+      });
+      const obj = item.toPersistenceObject();
+      
+      expect(obj.accountCategory).toBeUndefined();
+      expect(obj.taxNote).toBeUndefined();
+    });
+  });
+
+  describe('toCsvData', () => {
+    it('CSV用のデータに変換できる', () => {
+      const item = ReceiptItem.create(validProps);
+      const csvData = item.toCsvData();
+      
+      expect(csvData.購入日).toBe('2024年1月15日');
+      expect(csvData.商品名).toBe('テストアイテム');
+      expect(csvData.金額).toBe('1,000 JPY');
+      expect(csvData.勘定科目).toBe('消耗品費');
+      expect(csvData.税務メモ).toBe('消費税10%');
+    });
+
+    it('オプショナルな値がない場合も正しく変換できる', () => {
+      const item = ReceiptItem.create({
+        name: 'シンプルアイテム',
+        priceInYen: 500,
+        purchaseDate: '2024-01-15'
+      });
+      const csvData = item.toCsvData();
+      
+      expect(csvData.勘定科目).toBe('');
+      expect(csvData.税務メモ).toBe('');
+    });
+  });
+
+  describe('toString', () => {
+    it('適切な文字列表現を返す', () => {
+      const item = ReceiptItem.create(validProps);
+      const str = item.toString();
+      
+      expect(str).toContain('テストアイテム');
+      expect(str).toContain('1,000 JPY');
+      expect(str).toContain('消耗品費');
+      expect(str).toContain('2024年1月15日');
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- ReceiptItemドメインエンティティの実装
- レシート項目を表すドメインオブジェクトとして以下を含む：
  - ReceiptItemId: UUIDv4形式の一意識別子
  - ItemName: 商品名値オブジェクト
  - AccountCategory: 勘定科目値オブジェクト
  - TaxNote: 税務メモ値オブジェクト
  - ReceiptItem: メインエンティティクラス

## Test plan
- [x] 全ての値オブジェクトのバリデーション機能
- [x] エンティティの作成・復元・更新機能
- [x] ビジネスロジック（経費判定、高額商品判定）
- [x] データ変換機能（永続化用、CSV用、表示用）
- [x] エラーハンドリングとセキュリティ対策
- [x] 44個のテストケースで82.69%のカバレッジ達成
- [x] 型チェックとリント通過

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>