### PR TITLE
Fix timezone calculation test in ReceiptDate.spec.ts

### DIFF
--- a/api/src/tests/domain/value-objects/ReceiptDate.spec.ts
+++ b/api/src/tests/domain/value-objects/ReceiptDate.spec.ts
@@ -195,8 +195,10 @@ describe('ReceiptDate', () => {
       const utcNow = dayjs.utc();
       const japanNow = utcNow.add(9, 'hours');
       
-      // 日本時間がUTCより9時間進んでいることを確認
-      expect(japanNow.hour() - utcNow.hour()).toBe(9);
+      // 日本時間がUTCより9時間進んでいることを確認（日付境界の場合は24で調整）
+      const hourDiff = japanNow.hour() - utcNow.hour();
+      const expectedDiff = hourDiff < 0 ? hourDiff + 24 : hourDiff;
+      expect(expectedDiff).toBe(9);
     });
   });
 


### PR DESCRIPTION
## Summary

UTCとJST間の時差計算テストで日付境界をまたぐ場合の処理を修正しました。

## 問題

ReceiptDate.spec.ts の「日本時間の計算が正しく動作する」テストが、特定の時刻（UTC 21時以降）で実行されると失敗していました。

```
Expected: 9
Received: -15
```

## 原因

UTC時刻が21時以降の場合、JST（UTC+9）は翌日になるため：
- UTC 21:00 → JST 06:00（翌日）
- 時差計算: 6 - 21 = -15

## 解決策

日付境界をまたぐ場合の時差計算を正しく処理するよう修正：

```typescript
// 修正前
expect(japanNow.hour() - utcNow.hour()).toBe(9);

// 修正後  
const hourDiff = japanNow.hour() - utcNow.hour();
const expectedDiff = hourDiff < 0 ? hourDiff + 24 : hourDiff;
expect(expectedDiff).toBe(9);
```

## Test plan

- [x] 修正されたテストが通ることを確認
- [x] 全テストスイートが成功することを確認
- [x] 異なる時刻での実行でも安定することを確認
